### PR TITLE
feat: Add output kubernetes.namespace

### DIFF
--- a/modules/init/README.md
+++ b/modules/init/README.md
@@ -42,7 +42,7 @@ No modules.
 | <a name="output_app"></a> [app](#output\_app) | A map containing essentials about the application (id', 'name', 'project\_id', 'owner'). |
 | <a name="output_environment"></a> [environment](#output\_environment) | Environment descriptor (i.e. 'dev', 'tst', 'prd'). |
 | <a name="output_is_production"></a> [is\_production](#output\_is\_production) | Describes whether the environment in use is a production environment. |
-| <a name="output_kubernetes"></a> [kubernetes](#output\_kubernetes) | A map containing essentials about available Kubernetes cluster(s) ('project\_id'). |
+| <a name="output_kubernetes"></a> [kubernetes](#output\_kubernetes) | A map containing essentials about available Kubernetes cluster(s) ('project\_id', 'namespace'). |
 | <a name="output_labels"></a> [labels](#output\_labels) | Labels for use on managed resources (i.e. Kubernetes resources). |
 | <a name="output_networks"></a> [networks](#output\_networks) | A map containing essentials about available network(s) ('project\_id', 'vpc\_name', 'vpc\_id'). |
 | <a name="output_service_accounts"></a> [service\_accounts](#output\_service\_accounts) | A map containing essentials about application service account(s). |

--- a/modules/init/main.tf
+++ b/modules/init/main.tf
@@ -8,6 +8,7 @@ locals {
 
   kubernetes = {
     project_id = data.google_projects.kubernetes_projects.projects[0].project_id
+    namespace  = data.google_projects.app_projects.projects[0].labels.app
   }
 
   networks = {

--- a/modules/init/outputs.tf
+++ b/modules/init/outputs.tf
@@ -20,7 +20,7 @@ output "app" {
 }
 
 output "kubernetes" {
-  description = "A map containing essentials about available Kubernetes cluster(s) ('project_id')."
+  description = "A map containing essentials about available Kubernetes cluster(s) ('project_id', 'namespace')."
   value       = local.kubernetes
 }
 


### PR DESCRIPTION
Adds output `kubernetes.namespace`, to be used in subsequent references in other resources requiring a Kubernetes namespace value.

**Example:**
```
module "init" {
  source = "github.com/entur/terraform-google-init//modules/init?ref=vX"
  app_id = var.app_id
  environment = var.environment
}

resource "kubernetes_secret" "secret" {
  metadata {
    name = "foo"
    namespace = module.init.kubernetes.namespace
  }

  data = {
    ...
  }
} 
```

