### PR TITLE
fix: Remove filter restriction limiting module to standard apps

### DIFF
--- a/modules/init/main.tf
+++ b/modules/init/main.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 data "google_projects" "app_projects" {
-  filter = "lifecycleState:ACTIVE labels.purpose:app-project labels.app_id:${var.app_id} labels.environment:${var.environment}"
+  filter = "lifecycleState:ACTIVE labels.app_id:${var.app_id} labels.environment:${var.environment}"
 }
 
 data "google_projects" "kubernetes_projects" {


### PR DESCRIPTION
Removes filtering on label `purpose:app-project` in projects data source. This allows for use with other project types, such as Firebase projects or data projects.

Fixes #13 .

(Note that other modules consuming the init module may be incompatible with project types other than the standard "app-project" type.)