### PR TITLE
feat: Add export of project number and default project sa for pubsub

### DIFF
--- a/modules/init/README.md
+++ b/modules/init/README.md
@@ -39,11 +39,11 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_app"></a> [app](#output\_app) | A map containing essentials about the application (id', 'name', 'project\_id', 'owner'). |
+| <a name="output_app"></a> [app](#output\_app) | A map containing essentials about the application (id', 'name', 'project\_id', 'project\_number', 'owner'). |
 | <a name="output_environment"></a> [environment](#output\_environment) | Environment descriptor (i.e. 'dev', 'tst', 'prd'). |
 | <a name="output_is_production"></a> [is\_production](#output\_is\_production) | Describes whether the environment in use is a production environment. |
 | <a name="output_kubernetes"></a> [kubernetes](#output\_kubernetes) | A map containing essentials about available Kubernetes cluster(s) ('project\_id', 'namespace'). |
 | <a name="output_labels"></a> [labels](#output\_labels) | Labels for use on managed resources (i.e. Kubernetes resources). |
 | <a name="output_networks"></a> [networks](#output\_networks) | A map containing essentials about available network(s) ('project\_id', 'vpc\_name', 'vpc\_id'). |
-| <a name="output_service_accounts"></a> [service\_accounts](#output\_service\_accounts) | A map containing essentials about application service account(s). |
+| <a name="output_service_accounts"></a> [service\_accounts](#output\_service\_accounts) | A map containing essentials about application and project service account(s). |
 <!-- END_TF_DOCS -->

--- a/modules/init/main.tf
+++ b/modules/init/main.tf
@@ -1,9 +1,10 @@
 locals {
   app = {
-    id         = var.app_id
-    name       = data.google_projects.app_projects.projects[0].labels.app
-    owner      = data.google_projects.app_projects.projects[0].labels.owner
-    project_id = data.google_projects.app_projects.projects[0].project_id
+    id             = var.app_id
+    name           = data.google_projects.app_projects.projects[0].labels.app
+    owner          = data.google_projects.app_projects.projects[0].labels.owner
+    project_id     = data.google_projects.app_projects.projects[0].project_id
+    project_number = data.google_projects.app_projects.projects[0].number
   }
 
   kubernetes = {
@@ -19,6 +20,11 @@ locals {
 
   service_accounts = {
     default = data.google_service_account.application_default
+    project_defaults = {
+      pubsub = {
+        email = "service-${data.google_projects.app_projects.projects[0].number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+      }
+    }
   }
 
   is_production = try(data.google_projects.app_projects.projects[0].labels.is_prod, "false")


### PR DESCRIPTION
Adds two new outputs:
* `app.project_number`: The project number id
* `service_accounts.project_defaults.pubsub.email`: The email of the default project service account for pubsub, used when messages are published to dead letter topics, etc.
   (As the google Terraform provider lacks support for datasourcing this service account. Constructed, not data sourced.) 